### PR TITLE
cleanup per golint; make MaxIterations settable in Builder

### DIFF
--- a/fusefilter.go
+++ b/fusefilter.go
@@ -97,7 +97,7 @@ func PopulateFuse8(keys []uint64) (*Fuse8, error) {
 	iterations := 0
 	for true {
 		iterations += 1
-		if iterations > MaxIterations {
+		if iterations > DefaultMaxIterations {
 			return nil, errors.New("too many iterations, you probably have duplicate keys")
 		}
 

--- a/xor16.go
+++ b/xor16.go
@@ -10,6 +10,7 @@ type Xor16 struct {
 	Fingerprints []uint16
 }
 
+// Populate16 creates an xor filter with approx 16 bits per element.
 func Populate16(keys []uint64) (*Xor16, error) {
 	var bld Builder
 	return bld.Populate16(keys)
@@ -37,6 +38,7 @@ func (filter *Xor16) allocate(size int) {
 	filter.BlockLength = capacity / 3
 }
 
+// Populate16 creates an xor filter with approx 16 bits per element.
 func (bld *Builder) Populate16(keys []uint64) (*Xor16, error) {
 	size := len(keys)
 	filter := new(Xor16)

--- a/xor32.go
+++ b/xor32.go
@@ -4,11 +4,13 @@ import (
 	"math"
 )
 
+// Xor32 holds an xorfilter with approximately 32 bits per element and about one in a billion false positives.
 type Xor32 struct {
 	XorFilterCommon
 	Fingerprints []uint32
 }
 
+// Populate32 creates an xor filter with approx 32 bits per element.
 func Populate32(keys []uint64) (*Xor32, error) {
 	var bld Builder
 	return bld.Populate32(keys)
@@ -36,6 +38,7 @@ func (filter *Xor32) allocate(size int) {
 	filter.BlockLength = capacity / 3
 }
 
+// Populate32 creates an xor filter with approx 32 bits per element.
 func (bld *Builder) Populate32(keys []uint64) (*Xor32, error) {
 	size := len(keys)
 	filter := new(Xor32)

--- a/xorN.go
+++ b/xorN.go
@@ -15,6 +15,7 @@ type XorN struct {
 	Fingerprints []uint32
 }
 
+// PopulateN creates an xor filter with tunable number of bits per element.
 func PopulateN(keys []uint64, bits int) (*XorN, error) {
 	var bld Builder
 	return bld.PopulateN(keys, bits)
@@ -47,6 +48,7 @@ func (filter *XorN) allocate(size int) {
 	filter.BlockLength = capacity / 3
 }
 
+// PopulateN creates an xor filter with tunable number of bits per element.
 func (bld *Builder) PopulateN(keys []uint64, bits int) (*XorN, error) {
 	size := len(keys)
 	filter := new(XorN)

--- a/xorfilter_definitions.go
+++ b/xorfilter_definitions.go
@@ -6,6 +6,7 @@ type Xor8 struct {
 	Fingerprints []uint8
 }
 
+// XorFilterCommon gets embedded into Xor8, Xor16, Xor32, XorN
 type XorFilterCommon struct {
 	Seed        uint64
 	BlockLength uint32


### PR DESCRIPTION
golint cleanup
MaxIterations moves into the Builder to be configurable by code where it's used.
I think this will become tag v0.1.0